### PR TITLE
`addFiles` to add multiple files at once, passed as a dictionary

### DIFF
--- a/src/fs-helpers.ts
+++ b/src/fs-helpers.ts
@@ -18,6 +18,7 @@ export interface JsonFile<T> extends File {
 }
 export interface DirectoryApi {
   add(file: File): File;
+  addFiles(files: Record<string, string | object | null | undefined>): File[];
   addFile(...args: Parameters<typeof file>): File;
   addJsonFile(...args: Parameters<typeof jsonFile>): JsonFile<any>;
   dir(dirPath: string, cb?: (dir: DirectoryApi) => void): DirectoryApi;
@@ -80,6 +81,15 @@ function projectInternal(cwd: string) {
       files.push(file);
       return file;
     }
+    function addFiles(files: Record<string, string | object | null | undefined>) {
+      return Object.entries(files).map(([path, content]) => {
+        if(typeof content === 'string') {
+          return addFile(path, content);
+        } else if(content !== undefined) {
+          return addJsonFile(path, content);
+        }
+      });
+    }
     function addFile(...args: Parameters<typeof file>) {
       return add(file(...args));
     }
@@ -91,6 +101,7 @@ function projectInternal(cwd: string) {
     }
     const _dir: DirectoryApi = {
       add,
+      addFiles,
       addFile,
       addJsonFile,
       dir,


### PR DESCRIPTION
Motivation: this style looks nicer coming out of code formatters.

For example: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAHAThAVnMMB0AhgCbEBiAlgDZwAUA5BVMXAB74wDO9ANAAQQABgB0ofPgFsArlRjUmcPpwhT0YRZBajBASgDcojNlwES5anXoQYACzjoO3fkNHjps+VEXLV6vprhtfVFDTBw8IlJKGk5aYFc+RmY2R3okARExcUkZOSoFJRU1DQgtLMEeBKtbe1T0lyy3XM9vIr8AhMyAX30QHhAIVDloTmRQQnRMAHcABQmEUZRCKinCAE9R-oAjdEIwAGs4GABlQgk4ABkFZAAzZc44bd2Do+PUPaYAc2QYdClHkBwCRbOCkUEXQhQT5SQifOBkCDoCSEGByKHIECEKQwCB9EA2GASKgAdRsFHgnHe6mOC3JFAAbuS1hiwJxNiAmA90DAZrtPsjbvcAVhOKxjl8aABFKTWOCCqgPfrvdBcjFbQggqh4jBMGDEijEWzIAAcAAYlZgHsTdqgMRg4Fz6XL+gBHGXwXmDRaYzgAWi8oNBePQcDdFBDvNhAqQdwVAIeEgoPz+8YlcAAgqj0BQtti4DN7FcvPLFSBOGnpbKSwCYBr9YabMgAEz9X6ETyfADCEAk0cBnAArHipA8ACoaxax0v0-4ASWSsGOYGzQ3TzGOMDWNGrXS6QA